### PR TITLE
Adjust tapping term for hold behaviors

### DIFF
--- a/config/moNa2.keymap
+++ b/config/moNa2.keymap
@@ -9,6 +9,7 @@
 
 &mt {
     flavor = "balanced";
+    tapping-term-ms = <300>;
     quick-tap-ms = <0>;
 };
 
@@ -31,7 +32,7 @@
             bindings = <&mo>, <&to_layer_0>;
 
             #binding-cells = <2>;
-            tapping-term-ms = <200>;
+            tapping-term-ms = <300>;
         };
 
         scroll_up_down: behavior_sensor_rotate_mouse_wheel_up_down {


### PR DESCRIPTION
## Summary
- increase the tapping term for the global mod-tap override to 300 ms
- lengthen the tapping window for the custom layer-tap behavior to 300 ms

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d85838fb6c83208b1170f54d8394d6