### PR TITLE
Enable automouse layer

### DIFF
--- a/config/boards/shields/moNa2/moNa2_R.overlay
+++ b/config/boards/shields/moNa2/moNa2_R.overlay
@@ -55,7 +55,7 @@
         reg = <0>;
         spi-max-frequency = <2000000>;
         irq-gpios = <&gpio0 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-    //    automouse-layer = <5>;
+        automouse-layer = <5>;
         scroll-layers = <6>;
 
     };


### PR DESCRIPTION
## Summary
- enable the automouse-layer setting on the trackball to restore automatic mouse layer activation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69342c6a67588320b658cf56f8b6302a)